### PR TITLE
Update config variables to follow standard naming scheme

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+0.4.0 (2024-10-28)
+------------------
+
+* Added scribe context
+* Update config variables to follow standard naming scheme.
+
 0.3.0 (2024-10-11)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ scribe_plug = Plug(
     package_name="git+https://github.com/ohcnetwork/care_scribe.git",
     version="@master",
     configs={
-        "TRANSCRIBE_SERVICE_PROVIDER_API_KEY": "secret",
-        "API_PROVIDER": "openai",  # or "azure"
-        "AZURE_API_VERSION": "",  # required if API_PROVIDER is "azure"
-        "AZURE_ENDPOINT": "",  # required if API_PROVIDER is "azure"
-        "AUDIO_MODEL_NAME": "",  # model name for OpenAI or custom deployment name for Azure
-        "CHAT_MODEL_NAME": "",  # model name for OpenAI or custom deployment name for Azure
+        "SCRIBE_SERVICE_PROVIDER_API_KEY": "secret",
+        "SCRIBE_SERVICE_PROVIDER": "openai",  # or "azure"
+        "SCRIBE_AZURE_API_VERSION": "",  # required if SCRIBE_SERVICE_PROVIDER is "azure"
+        "SCRIBE_AZURE_ENDPOINT": "",  # required if SCRIBE_SERVICE_PROVIDER is "azure"
+        "SCRIBE_AUDIO_MODEL": "",  # model name for OpenAI or custom deployment name for Azure
+        "SCRIBE_CHAT_MODEL": "",  # model name for OpenAI or custom deployment name for Azure
     },
 )
 plugs = [scribe_plug]
@@ -44,12 +44,12 @@ plugs = [scribe_plug]
 
 The following configurations variables are available for Care Scribe:
 
-- `TRANSCRIBE_SERVICE_PROVIDER_API_KEY`: API key for the transcribe service provider (OpenAI whisper or Google Speech to Text)
-- `API_PROVIDER`: The API provider to use for transcription. Can be either "openai" or "azure".
-- `AZURE_API_VERSION`: The version of the Azure API to use. This is required if `API_PROVIDER` is set to "azure".
-- `AZURE_ENDPOINT`: The endpoint for the Azure API. This is required if `API_PROVIDER` is set to "azure".
-- `AUDIO_MODEL_NAME`: The model name for OpenAI or the custom deployment name for Azure.
-- `CHAT_MODEL_NAME`: The model name for OpenAI or the custom deployment name for Azure.
+- `SCRIBE_SERVICE_PROVIDER_API_KEY`: API key for the transcribe service provider (OpenAI whisper or Google Speech to Text)
+- `SCRIBE_SERVICE_PROVIDER`: The API provider to use for transcription. Can be either "openai" or "azure".
+- `SCRIBE_AZURE_API_VERSION`: The version of the Azure API to use. This is required if `SCRIBE_SERVICE_PROVIDER` is set to "azure".
+- `SCRIBE_AZURE_ENDPOINT`: The endpoint for the Azure API. This is required if `SCRIBE_SERVICE_PROVIDER` is set to "azure".
+- `SCRIBE_AUDIO_MODEL`: The model name for OpenAI or the custom deployment name for Azure.
+- `SCRIBE_CHAT_MODEL`: The model name for OpenAI or the custom deployment name for Azure.
 
 The plugin will try to find the API key from the config first and then from the environment variable.
 

--- a/care_scribe/__init__.py
+++ b/care_scribe/__init__.py
@@ -1,3 +1,3 @@
 __author__ = """Open Healthcare Network"""
 __email__ = "info@ohc.network"
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/care_scribe/settings.py
+++ b/care_scribe/settings.py
@@ -86,14 +86,14 @@ class PluginSettings:  # pragma: no cover
                     f'Please set the "{setting}" in the environment or the {PLUGIN_NAME} plugin config.'
                 )
 
-        if getattr(self, "API_PROVIDER") not in ("openai", "azure"):
+        if getattr(self, "SCRIBE_SERVICE_PROVIDER") not in ("openai", "azure"):
             raise ImproperlyConfigured(
-                'Invalid value for "API_PROVIDER". '
-                'Please set the "API_PROVIDER" to "openai" or "azure".'
+                'Invalid value for "SCRIBE_SERVICE_PROVIDER". '
+                'Please set the "SCRIBE_SERVICE_PROVIDER" to "openai" or "azure".'
             )
 
-        if getattr(self, "API_PROVIDER") == "azure":
-            for setting in ("AZURE_API_VERSION", "AZURE_ENDPOINT"):
+        if getattr(self, "SCRIBE_SERVICE_PROVIDER") == "azure":
+            for setting in ("SCRIBE_AZURE_API_VERSION", "SCRIBE_AZURE_ENDPOINT"):
                 if not getattr(self, setting):
                     raise ImproperlyConfigured(
                         f'The "{setting}" setting is required when using Azure API. '
@@ -112,19 +112,19 @@ class PluginSettings:  # pragma: no cover
 
 
 REQUIRED_SETTINGS = {
-    "TRANSCRIBE_SERVICE_PROVIDER_API_KEY",
-    "AUDIO_MODEL_NAME",
-    "CHAT_MODEL_NAME",
-    "API_PROVIDER",
+    "SCRIBE_SERVICE_PROVIDER_API_KEY",
+    "SCRIBE_AUDIO_MODEL",
+    "SCRIBE_CHAT_MODEL",
+    "SCRIBE_SERVICE_PROVIDER",
 }
 
 DEFAULTS = {
-    "TRANSCRIBE_SERVICE_PROVIDER_API_KEY": "",
-    "AUDIO_MODEL_NAME": "whisper-1",
-    "CHAT_MODEL_NAME": "gpt-4-turbo",
-    "API_PROVIDER": "openai",
-    "AZURE_API_VERSION": "",
-    "AZURE_ENDPOINT": "",
+    "SCRIBE_SERVICE_PROVIDER_API_KEY": "",
+    "SCRIBE_AUDIO_MODEL": "whisper-1",
+    "SCRIBE_CHAT_MODEL": "gpt-4-turbo",
+    "SCRIBE_SERVICE_PROVIDER": "openai",
+    "SCRIBE_AZURE_API_VERSION": "",
+    "SCRIBE_AZURE_ENDPOINT": "",
 }
 
 plugin_settings = PluginSettings(

--- a/care_scribe/tasks/scribe.py
+++ b/care_scribe/tasks/scribe.py
@@ -17,18 +17,18 @@ AiClient = None
 def get_openai_client():
     global AiClient
     if AiClient is None:
-        if plugin_settings.API_PROVIDER == 'azure':
+        if plugin_settings.SCRIBE_SERVICE_PROVIDER == 'azure':
             AiClient = AzureOpenAI(
-                api_key=plugin_settings.TRANSCRIBE_SERVICE_PROVIDER_API_KEY,
-                api_version=plugin_settings.AZURE_API_VERSION,
-                azure_endpoint=plugin_settings.AZURE_ENDPOINT
+                api_key=plugin_settings.SCRIBE_SERVICE_PROVIDER_API_KEY,
+                api_version=plugin_settings.SCRIBE_AZURE_API_VERSION,
+                azure_endpoint=plugin_settings.SCRIBE_AZURE_ENDPOINT
             )
-        elif plugin_settings.API_PROVIDER == 'openai':
+        elif plugin_settings.SCRIBE_SERVICE_PROVIDER == 'openai':
             AiClient = OpenAI(
-                api_key=plugin_settings.TRANSCRIBE_SERVICE_PROVIDER_API_KEY
+                api_key=plugin_settings.SCRIBE_SERVICE_PROVIDER_API_KEY
             )
         else:
-            raise Exception('Invalid API_PROVIDER in plugin_settings')
+            raise Exception('Invalid SCRIBE_SERVICE_PROVIDER in plugin_settings')
     return AiClient
 
 
@@ -87,7 +87,7 @@ def process_ai_form_fill(external_id):
                     buffer.name = "file.mp3"
 
                     transcription = get_openai_client().audio.translations.create(
-                        model=plugin_settings.AUDIO_MODEL_NAME, file=buffer # This can be the model name (OPENAI) or the custom deployment name (AZURE)
+                        model=plugin_settings.SCRIBE_AUDIO_MODEL, file=buffer # This can be the model name (OPENAI) or the custom deployment name (AZURE)
                     )
                     transcript += transcription.text
                     logger.info(f"Transcript: {transcript}")
@@ -104,7 +104,7 @@ def process_ai_form_fill(external_id):
 
             # Process the transcript with Ayushma
             ai_response = get_openai_client().chat.completions.create(
-                model=plugin_settings.CHAT_MODEL_NAME, # This can be the model name (OPENAI) or the custom deployment name (AZURE) 
+                model=plugin_settings.SCRIBE_CHAT_MODEL, # This can be the model name (OPENAI) or the custom deployment name (AZURE) 
                 response_format={"type": "json_object"},
                 max_tokens=4096,
                 temperature=0,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.4.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/ohcnetwork/care_scribe",
-    version="0.3.0",
+    version="0.4.0",
     zip_safe=False,
 )


### PR DESCRIPTION
This pull request updates the config variables in the codebase to follow a standard naming scheme. The changes ensure that the config variables related to the transcribe service provider (previously named TRANSCRIBE_SERVICE_PROVIDER_API_KEY, API_PROVIDER, AZURE_API_VERSION, AZURE_ENDPOINT, AUDIO_MODEL_NAME, and CHAT_MODEL_NAME) are now named SCRIBE_SERVICE_PROVIDER_API_KEY, SCRIBE_SERVICE_PROVIDER, SCRIBE_AZURE_API_VERSION, SCRIBE_AZURE_ENDPOINT, SCRIBE_AUDIO_MODEL, and SCRIBE_CHAT_MODEL respectively.